### PR TITLE
add support for merchant_ fields on order and cart item

### DIFF
--- a/lib/klarna/checkout/cart_item.rb
+++ b/lib/klarna/checkout/cart_item.rb
@@ -7,7 +7,8 @@ module Klarna
 
       attr_accessor :type, :ean, :reference, :name, :uri, :image_uri, :quantity,
                     :unit_price, :total_price_excluding_tax, :total_tax_amount,
-                    :total_price_including_tax, :discount_rate, :tax_rate
+                    :total_price_including_tax, :discount_rate, :tax_rate,
+                    :merchant_item_data
 
       validates_presence_of :reference, :name, :quantity, :unit_price, :tax_rate
 
@@ -22,7 +23,8 @@ module Klarna
           :quantity => @quantity,
           :unit_price => @unit_price,
           :discount_rate => @discount_rate,
-          :tax_rate => @tax_rate
+          :tax_rate => @tax_rate,
+          :merchant_item_data => @merchant_item_data
         })
       end
     end

--- a/lib/klarna/checkout/order.rb
+++ b/lib/klarna/checkout/order.rb
@@ -8,7 +8,7 @@ module Klarna
 
       attr_accessor :id, :status, :reference, :reservation, :started_at,
                     :completed_at, :created_at, :last_modified_at, :expires_at,
-                    :locale
+                    :locale, :merchant_order_data
 
       attr_accessor :purchase_country, :purchase_currency
 
@@ -30,6 +30,7 @@ module Klarna
           :purchase_country   => @purchase_country,
           :purchase_currency  => @purchase_currency,
           :locale             => @locale,
+          :merchant_order_data => @merchant_order_data,
           :cart     => @cart.as_json,
           :gui      => (@gui && @gui.as_json),
           :merchant => @merchant.as_json,

--- a/spec/lib/klarna/checkout/cart_spec.rb
+++ b/spec/lib/klarna/checkout/cart_spec.rb
@@ -38,7 +38,8 @@ describe Klarna::Checkout::Cart do
           total_tax_amount: 50,
           total_price_including_tax: 250,
           discount_rate: 0,
-          tax_rate: 2500
+          tax_rate: 2500,
+          merchant_item_data: 'size=L;'
         }]
     end
 
@@ -50,16 +51,17 @@ describe Klarna::Checkout::Cart do
     describe "items/0" do
       subject { json_hash[:items][0] }
 
-      its([:type])                      { should eq 'physical' }          
-      its([:ean])                       { should eq '1123581220325' }        
-      its([:reference])                 { should eq '1123581220325' }              
-      its([:name])                      { should eq 'Widget' }          
-      its([:uri])                       { should eq 'http://www.example.com/product-uri' }        
-      its([:image_uri])                 { should eq 'http://www.example.com/product-image-uri' }              
-      its([:quantity])                  { should eq 1 }              
-      its([:unit_price])                { should eq 250 }                
+      its([:type])                      { should eq 'physical' }
+      its([:ean])                       { should eq '1123581220325' }
+      its([:reference])                 { should eq '1123581220325' }
+      its([:name])                      { should eq 'Widget' }
+      its([:uri])                       { should eq 'http://www.example.com/product-uri' }
+      its([:image_uri])                 { should eq 'http://www.example.com/product-image-uri' }
+      its([:quantity])                  { should eq 1 }
+      its([:unit_price])                { should eq 250 }
       its([:discount_rate])             { should eq 0 }
       its([:tax_rate])                  { should eq 2500 }
+      its([:merchant_item_data])        { should eq 'size=L;' }
     end
   end
 end

--- a/spec/lib/klarna/checkout/order_spec.rb
+++ b/spec/lib/klarna/checkout/order_spec.rb
@@ -47,6 +47,7 @@ describe Klarna::Checkout::Order do
         purchase_country:   'NO',
         purchase_currency:  'NOK',
         locale: 'nb-no',
+        merchant_order_data: 'ref=test;',
         cart: {
           items: [{
             reference:  '1123581220325',


### PR DESCRIPTION
It seems not to be documented in Klarna doc but you can send in additional data in `merchant_order_data` on order and `merchant_item_data` on cart item.
